### PR TITLE
Add grocery lists and items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+.elixir_ls
+
+.vscode

--- a/lib/grok_store/groceries.ex
+++ b/lib/grok_store/groceries.ex
@@ -1,0 +1,219 @@
+defmodule GrokStore.Groceries do
+  @moduledoc """
+  The Groceries context.
+  """
+
+  import Ecto.Query, warn: false
+  alias GrokStore.Repo
+
+  alias GrokStore.Groceries.List
+
+  @doc """
+  Returns the list of lists.
+
+  ## Examples
+
+      iex> list_lists()
+      [%List{}, ...]
+
+  """
+  def list_lists do
+    Repo.all(List)
+  end
+
+  @doc """
+  Gets a single list.
+
+  Raises `Ecto.NoResultsError` if the List does not exist.
+
+  ## Examples
+
+      iex> get_list!(123)
+      %List{}
+
+      iex> get_list!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_list!(id), do: Repo.get!(List, id)
+
+  @doc """
+  Creates a list.
+
+  ## Examples
+
+      iex> create_list(%{field: value})
+      {:ok, %List{}}
+
+      iex> create_list(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_list(attrs \\ %{}) do
+    %List{}
+    |> List.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a list.
+
+  ## Examples
+
+      iex> update_list(list, %{field: new_value})
+      {:ok, %List{}}
+
+      iex> update_list(list, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_list(%List{} = list, attrs) do
+    list
+    |> List.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a List.
+
+  ## Examples
+
+      iex> delete_list(list)
+      {:ok, %List{}}
+
+      iex> delete_list(list)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_list(%List{} = list) do
+    Repo.delete(list)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking list changes.
+
+  ## Examples
+
+      iex> change_list(list)
+      %Ecto.Changeset{source: %List{}}
+
+  """
+  def change_list(%List{} = list) do
+    List.changeset(list, %{})
+  end
+
+  alias GrokStore.Groceries.ListItem
+
+  @doc """
+  Returns the list of list_items.
+
+  ## Examples
+
+      iex> list_list_items()
+      [%ListItem{}, ...]
+
+  """
+  def list_list_items do
+    Repo.all(ListItem)
+  end
+
+  @doc """
+  Gets a single list_item.
+
+  Raises `Ecto.NoResultsError` if the List item does not exist.
+
+  ## Examples
+
+      iex> get_list_item!(123)
+      %ListItem{}
+
+      iex> get_list_item!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_list_item!(id), do: Repo.get!(ListItem, id)
+
+  @doc """
+  Creates a list_item.
+
+  ## Examples
+
+      iex> create_list_item(%{field: value})
+      {:ok, %ListItem{}}
+
+      iex> create_list_item(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_list_item(attrs \\ %{}) do
+    %ListItem{}
+    |> ListItem.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a list_item.
+
+  ## Examples
+
+      iex> update_list_item(list_item, %{field: new_value})
+      {:ok, %ListItem{}}
+
+      iex> update_list_item(list_item, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_list_item(%ListItem{} = list_item, attrs) do
+    list_item
+    |> ListItem.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a ListItem.
+
+  ## Examples
+
+      iex> delete_list_item(list_item)
+      {:ok, %ListItem{}}
+
+      iex> delete_list_item(list_item)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_list_item(%ListItem{} = list_item) do
+    Repo.delete(list_item)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking list_item changes.
+
+  ## Examples
+
+      iex> change_list_item(list_item)
+      %Ecto.Changeset{source: %ListItem{}}
+
+  """
+  def change_list_item(%ListItem{} = list_item) do
+    ListItem.changeset(list_item, %{})
+  end
+
+  @doc """
+  Puts an item in the list
+  """
+  def add_item_to_list(list, attrs \\ %{}) do
+    list
+    |> Ecto.build_assoc(:list_items, attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Returns all the items in a list
+  """
+  def list_items_in_list(%List{} = list) do
+    from(i in ListItem,
+      where: i.list_id == ^list.id
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/grok_store/groceries/list.ex
+++ b/lib/grok_store/groceries/list.ex
@@ -1,0 +1,18 @@
+defmodule GrokStore.Groceries.List do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "lists" do
+    field :title, :string
+    has_many :list_items, GrokStore.Groceries.ListItem
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(list, attrs) do
+    list
+    |> cast(attrs, [:title])
+    |> validate_required([:title])
+  end
+end

--- a/lib/grok_store/groceries/list_item.ex
+++ b/lib/grok_store/groceries/list_item.ex
@@ -1,0 +1,22 @@
+defmodule GrokStore.Groceries.ListItem do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "list_items" do
+    field :checked, :boolean, default: false
+    field :location, :string
+    field :price, :float
+    field :quantity, :float
+    field :text, :string
+    belongs_to :list, GrokStore.Groceries.List
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(list_item, attrs) do
+    list_item
+    |> cast(attrs, [:text, :checked, :quantity, :price, :location])
+    |> validate_required([:text, :checked, :quantity, :price])
+  end
+end

--- a/lib/grok_store_web/resolvers/groceries.ex
+++ b/lib/grok_store_web/resolvers/groceries.ex
@@ -1,0 +1,9 @@
+defmodule GrokStoreWeb.Resolvers.Groceries do
+  def list_lists(_parent, _args, _context) do
+    {:ok, GrokStore.Groceries.list_lists()}
+  end
+
+  def list_list_items(list, _args, _context) do
+    {:ok, GrokStore.Groceries.list_items_in_list(list)}
+  end
+end

--- a/lib/grok_store_web/router.ex
+++ b/lib/grok_store_web/router.ex
@@ -19,8 +19,11 @@ defmodule GrokStoreWeb.Router do
     get "/", PageController, :index
   end
 
-  # Other scopes may use custom stacks.
-  # scope "/api", GrokStoreWeb do
-  #   pipe_through :api
-  # end
+  scope "/api" do
+    pipe_through :api
+
+    forward "/graphiql", Absinthe.Plug.GraphiQL, schema: GrokStoreWeb.Schema
+
+    forward "/", Absinthe.Plug, schema: GrokStoreWeb.Schema
+  end
 end

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -1,0 +1,14 @@
+defmodule GrokStoreWeb.Schema do
+  use Absinthe.Schema
+  import_types(Absinthe.Type.Custom)
+  import_types(GrokStoreWeb.Schema.GroceryTypes)
+
+  alias GrokStoreWeb.Resolvers
+
+  query do
+    @desc "Get all lists"
+    field :lists, list_of(:list) do
+      resolve(&Resolvers.Groceries.list_lists/3)
+    end
+  end
+end

--- a/lib/schema/grocery_types.ex
+++ b/lib/schema/grocery_types.ex
@@ -1,0 +1,25 @@
+defmodule GrokStoreWeb.Schema.GroceryTypes do
+  use Absinthe.Schema.Notation
+
+  alias GrokStoreWeb.Resolvers
+
+  @desc "A grocery list"
+  object :list do
+    field :id, :id
+    field :title, :string
+
+    field :items, list_of(:item) do
+      resolve(&Resolvers.Groceries.list_list_items/3)
+    end
+  end
+
+  @desc "An item in a grocery list"
+  object :item do
+    field :id, :id
+    field :checked, :boolean
+    field :location, :string
+    field :price, :float
+    field :quantity, :integer
+    field :text, :string
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,9 @@ defmodule GrokStore.MixProject do
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"}
+      {:plug_cowboy, "~> 2.0"},
+      {:absinthe_plug, "~> 1.4"},
+      {:absinthe, "~> 1.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
+  "absinthe": {:hex, :absinthe, "1.4.16", "0933e4d9f12652b12115d5709c0293a1bf78a22578032e9ad0dad4efee6b9eb1", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "absinthe_ecto": {:hex, :absinthe_ecto, "0.1.3", "420b68129e79fe4571a4838904ba03e282330d335da47729ad52ffd7b8c5fcb1", [:mix], [{:absinthe, "~> 1.3.0 or ~> 1.4.0", [hex: :absinthe, repo: "hexpm", optional: false]}, {:ecto, ">= 0.0.0", [hex: :ecto, repo: "hexpm", optional: false]}], "hexpm"},
+  "absinthe_plug": {:hex, :absinthe_plug, "1.4.7", "939b6b9e1c7abc6b399a5b49faa690a1fbb55b195c670aa35783b14b08ccec7a", [:mix], [{:absinthe, "~> 1.4.11", [hex: :absinthe, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.2 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},

--- a/priv/repo/migrations/20190610220305_create_lists.exs
+++ b/priv/repo/migrations/20190610220305_create_lists.exs
@@ -1,0 +1,12 @@
+defmodule GrokStore.Repo.Migrations.CreateLists do
+  use Ecto.Migration
+
+  def change do
+    create table(:lists) do
+      add :title, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20190610220517_create_list_items.exs
+++ b/priv/repo/migrations/20190610220517_create_list_items.exs
@@ -1,0 +1,18 @@
+defmodule GrokStore.Repo.Migrations.CreateListItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:list_items) do
+      add :text, :text
+      add :checked, :boolean, default: false, null: false
+      add :quantity, :integer
+      add :price, :float
+      add :location, :string
+      add :list_id, references(:lists, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:list_items, [:list_id])
+  end
+end

--- a/priv/repo/migrations/20190611134955_change_quantity_to_float.exs
+++ b/priv/repo/migrations/20190611134955_change_quantity_to_float.exs
@@ -1,0 +1,9 @@
+defmodule GrokStore.Repo.Migrations.ChangeQuantityToFloat do
+  use Ecto.Migration
+
+  def change do
+    alter table(:list_items) do
+      modify :quantity, :float
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,23 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+alias GrokStore.Groceries.{List, ListItem}
+alias GrokStore.Repo
+
+list = %List{title: "My grocery list"} |> Repo.insert!()
+
+%ListItem{
+  text: "Spaghetti sauce",
+  price: 3.99,
+  quantity: 2.0,
+  list_id: list.id
+}
+|> Repo.insert!()
+
+%ListItem{
+  text: "salmon",
+  price: 15.0,
+  quantity: 1.0,
+  list_id: list.id
+}
+|> Repo.insert!()

--- a/test/grok_store/groceries_test.exs
+++ b/test/grok_store/groceries_test.exs
@@ -1,0 +1,162 @@
+defmodule GrokStore.GroceriesTest do
+  use GrokStore.DataCase
+
+  alias GrokStore.Groceries
+
+  describe "lists" do
+    alias GrokStore.Groceries.List
+
+    @valid_attrs %{title: "some title"}
+    @update_attrs %{title: "some updated title"}
+    @invalid_attrs %{title: nil}
+
+    def list_fixture(attrs \\ %{}) do
+      {:ok, list} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Groceries.create_list()
+
+      list
+    end
+
+    test "list_lists/0 returns all lists" do
+      list = list_fixture()
+      assert Groceries.list_lists() == [list]
+    end
+
+    test "get_list!/1 returns the list with given id" do
+      list = list_fixture()
+      assert Groceries.get_list!(list.id) == list
+    end
+
+    test "create_list/1 with valid data creates a list" do
+      assert {:ok, %List{} = list} = Groceries.create_list(@valid_attrs)
+      assert list.title == "some title"
+    end
+
+    test "create_list/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Groceries.create_list(@invalid_attrs)
+    end
+
+    test "update_list/2 with valid data updates the list" do
+      list = list_fixture()
+      assert {:ok, %List{} = list} = Groceries.update_list(list, @update_attrs)
+      assert list.title == "some updated title"
+    end
+
+    test "update_list/2 with invalid data returns error changeset" do
+      list = list_fixture()
+      assert {:error, %Ecto.Changeset{}} = Groceries.update_list(list, @invalid_attrs)
+      assert list == Groceries.get_list!(list.id)
+    end
+
+    test "delete_list/1 deletes the list" do
+      list = list_fixture()
+      assert {:ok, %List{}} = Groceries.delete_list(list)
+      assert_raise Ecto.NoResultsError, fn -> Groceries.get_list!(list.id) end
+    end
+
+    test "change_list/1 returns a list changeset" do
+      list = list_fixture()
+      assert %Ecto.Changeset{} = Groceries.change_list(list)
+    end
+  end
+
+  describe "list_items" do
+    alias GrokStore.Groceries.ListItem
+
+    @valid_attrs %{
+      checked: true,
+      location: "some location",
+      price: 120.5,
+      quantity: 42,
+      text: "some text"
+    }
+    @update_attrs %{
+      checked: false,
+      location: "some updated location",
+      price: 456.7,
+      quantity: 43,
+      text: "some updated text"
+    }
+    @invalid_attrs %{checked: nil, location: nil, price: nil, quantity: nil, text: nil}
+
+    def list_item_fixture(attrs \\ %{}) do
+      {:ok, list_item} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Groceries.create_list_item()
+
+      list_item
+    end
+
+    test "list_list_items/0 returns all list_items" do
+      list_item = list_item_fixture()
+      assert Groceries.list_list_items() == [list_item]
+    end
+
+    test "get_list_item!/1 returns the list_item with given id" do
+      list_item = list_item_fixture()
+      assert Groceries.get_list_item!(list_item.id) == list_item
+    end
+
+    test "create_list_item/1 with valid data creates a list_item" do
+      assert {:ok, %ListItem{} = list_item} = Groceries.create_list_item(@valid_attrs)
+      assert list_item.checked == true
+      assert list_item.location == "some location"
+      assert list_item.price == 120.5
+      assert list_item.quantity == 42
+      assert list_item.text == "some text"
+    end
+
+    test "create_list_item/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Groceries.create_list_item(@invalid_attrs)
+    end
+
+    test "update_list_item/2 with valid data updates the list_item" do
+      list_item = list_item_fixture()
+      assert {:ok, %ListItem{} = list_item} = Groceries.update_list_item(list_item, @update_attrs)
+      assert list_item.checked == false
+      assert list_item.location == "some updated location"
+      assert list_item.price == 456.7
+      assert list_item.quantity == 43
+      assert list_item.text == "some updated text"
+    end
+
+    test "update_list_item/2 with invalid data returns error changeset" do
+      list_item = list_item_fixture()
+      assert {:error, %Ecto.Changeset{}} = Groceries.update_list_item(list_item, @invalid_attrs)
+      assert list_item == Groceries.get_list_item!(list_item.id)
+    end
+
+    test "delete_list_item/1 deletes the list_item" do
+      list_item = list_item_fixture()
+      assert {:ok, %ListItem{}} = Groceries.delete_list_item(list_item)
+      assert_raise Ecto.NoResultsError, fn -> Groceries.get_list_item!(list_item.id) end
+    end
+
+    test "change_list_item/1 returns a list_item changeset" do
+      list_item = list_item_fixture()
+      assert %Ecto.Changeset{} = Groceries.change_list_item(list_item)
+    end
+
+    test "add_item_to_list/2 adds an item to the list" do
+      {:ok, list} = Groceries.create_list(%{title: "A title"})
+
+      item = %{
+        text: "salmon",
+        price: 19.99,
+        quantity: 1.0
+      }
+
+      Groceries.add_item_to_list(list, item)
+
+      [list_item | []] = Groceries.list_items_in_list(list)
+
+      assert list_item.text == item[:text]
+      assert list_item.price == item[:price]
+      assert list_item.quantity == item[:quantity]
+      assert list_item.checked == false
+    end
+  end
+end

--- a/test/grok_store_web/absinthe/queries/list_test.exs
+++ b/test/grok_store_web/absinthe/queries/list_test.exs
@@ -1,0 +1,77 @@
+defmodule GrokStoreWeb.Absinthe.Queries.ListTest do
+  use GrokStoreWeb.ConnCase
+  alias GrokStoreWeb.Schema
+  alias GrokStore.Groceries
+
+  test "getting a list" do
+    {:ok, list} = Groceries.create_list(%{title: "A title"})
+
+    query = """
+    {
+      lists {
+        id
+        title
+      }
+    }
+    """
+
+    # will use the context once we have logged in users
+    context = %{}
+
+    {:ok, %{data: %{"lists" => lists}}} = Absinthe.run(query, Schema, context: context)
+
+    first_list = hd(lists)
+    assert first_list["title"] == list.title
+    assert Integer.parse(first_list["id"]) == {list.id, ""}
+  end
+
+  test "a list with items" do
+    {:ok, list} = Groceries.create_list(%{title: "A title"})
+
+    {:ok, item_1} =
+      Groceries.add_item_to_list(list, %{
+        text: "spag sauce",
+        price: 2.99,
+        quantity: 2.0,
+        list_id: list.id
+      })
+
+    {:ok, item_2} =
+      Groceries.add_item_to_list(list, %{
+        text: "salmon",
+        price: 19.99,
+        quantity: 1.0,
+        list_id: list.id
+      })
+
+    query = """
+    {
+      lists {
+        title
+        items {
+          id
+          text
+          price
+          quantity
+        }
+      }
+    }
+    """
+
+    context = %{}
+
+    {:ok, %{data: %{"lists" => lists}}} = Absinthe.run(query, Schema, context: context)
+
+    list_1 = hd(lists)
+    assert list_1["title"] == list.title
+
+    [first_item, second_item | []] = Enum.sort_by(list_1["items"], & &1["id"])
+    assert first_item["text"] == item_1.text
+    assert first_item["price"] == item_1.price
+    assert first_item["quantity"] == item_1.quantity
+
+    assert second_item["text"] == item_2.text
+    assert second_item["price"] == item_2.price
+    assert second_item["quantity"] == item_2.quantity
+  end
+end


### PR DESCRIPTION
Add grocery `lists` and `list_items` to the database and a couple
convenience functions for working with them.

Also adds basic graphql querying for lists.