### PR TITLE
Add a mutation to add list items

### DIFF
--- a/lib/grok_store/accounts.ex
+++ b/lib/grok_store/accounts.ex
@@ -145,4 +145,22 @@ defmodule GrokStore.Accounts do
         end
     end
   end
+
+  @doc """
+  Gets a list by id if the user is a member of it. Returns nil otherwise.
+  """
+  def get_user_list(user, list_id) do
+    query =
+      from l in GList,
+        where: l.id == ^list_id,
+        preload: :users
+
+    list = Repo.one(query)
+
+    if list && Enum.any?(list.users, fn l_user -> l_user.id == user.id end) do
+      list
+    else
+      nil
+    end
+  end
 end

--- a/lib/grok_store_web/resolvers/accounts.ex
+++ b/lib/grok_store_web/resolvers/accounts.ex
@@ -2,6 +2,8 @@ defmodule GrokStoreWeb.Resolvers.Accounts do
   alias GrokStoreWeb.Auth.Guardian
   alias GrokStoreWeb.Auth.Helper
   alias GrokStore.Accounts
+  alias GrokStore.Repo
+  require Logger
 
   def create_user(%{name: name, email: email, password: password}, _info) do
     Accounts.create_user(%{
@@ -32,5 +34,12 @@ defmodule GrokStoreWeb.Resolvers.Accounts do
       user ->
         {:ok, user}
     end
+  end
+
+  def list_list_users(parent, _args, _info) do
+    Logger.info(inspect(parent))
+    loaded = Repo.preload(parent, :users)
+    Logger.info(inspect(loaded))
+    {:ok, loaded.users}
   end
 end

--- a/lib/grok_store_web/resolvers/groceries.ex
+++ b/lib/grok_store_web/resolvers/groceries.ex
@@ -1,6 +1,9 @@
 defmodule GrokStoreWeb.Resolvers.Groceries do
   require Logger
 
+  alias GrokStore.Groceries
+  alias GrokStore.Accounts
+
   def list_lists(_parent, _args, %{context: %{user: user}}) do
     {:ok, GrokStore.Groceries.list_lists(user)}
   end
@@ -11,5 +14,29 @@ defmodule GrokStoreWeb.Resolvers.Groceries do
 
   def list_list_items(list, _args, _context) do
     {:ok, GrokStore.Groceries.list_items_in_list(list)}
+  end
+
+  def create_list(_parent, args, %{context: %{user: user}}) do
+    {:ok, list} = Groceries.create_list(args)
+    {:ok, _user} = Accounts.add_list(user, list)
+    {:ok, list}
+  end
+
+  def create_list(_parent, _args, _info) do
+    {:error, "You must be signed in to create a list"}
+  end
+
+  def add_item(_parent, args, %{context: %{user: user}}) do
+    case Accounts.get_user_list(user, args[:list_id]) do
+      nil ->
+        {:error, "You must be a member of the list to add to it"}
+
+      list ->
+        GrokStore.Groceries.add_item_to_list(list, args)
+    end
+  end
+
+  def add_item(_parent, _args, _info) do
+    {:error, "You must be signed in to add an item to a list"}
   end
 end

--- a/lib/grok_store_web/schema/account_types.ex
+++ b/lib/grok_store_web/schema/account_types.ex
@@ -1,6 +1,5 @@
-defmodule GrokStorWeb.Schema.AccountTypes do
+defmodule GrokStoreWeb.Schema.AccountTypes do
   use Absinthe.Schema.Notation
-  alias GrokStoreWeb.Resolvers
 
   @desc "A user"
   object :user do

--- a/lib/grok_store_web/schema/grocery_types.ex
+++ b/lib/grok_store_web/schema/grocery_types.ex
@@ -8,6 +8,10 @@ defmodule GrokStoreWeb.Schema.GroceryTypes do
     field :id, :id
     field :title, :string
 
+    field :users, list_of(:user) do
+      resolve(&Resolvers.Accounts.list_list_users/3)
+    end
+
     field :items, list_of(:item) do
       resolve(&Resolvers.Groceries.list_list_items/3)
     end
@@ -21,5 +25,6 @@ defmodule GrokStoreWeb.Schema.GroceryTypes do
     field :price, :float
     field :quantity, :integer
     field :text, :string
+    field :list_id, :id
   end
 end

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -2,7 +2,7 @@ defmodule GrokStoreWeb.Schema do
   use Absinthe.Schema
   import_types(Absinthe.Type.Custom)
   import_types(GrokStoreWeb.Schema.GroceryTypes)
-  import_types(GrokStorWeb.Schema.AccountTypes)
+  import_types(GrokStoreWeb.Schema.AccountTypes)
 
   alias GrokStoreWeb.Resolvers
 
@@ -33,6 +33,21 @@ defmodule GrokStoreWeb.Schema do
       arg(:email, non_null(:string))
       arg(:password, non_null(:string))
       resolve(&Resolvers.Accounts.login/2)
+    end
+
+    @desc "Create a list for the signed in user. Will error if there is not user signed in"
+    field :create_list, type: :list do
+      arg(:title, non_null(:string))
+      resolve(&Resolvers.Groceries.create_list/3)
+    end
+
+    @desc "Adds an item to the list"
+    field :add_item, type: :item do
+      arg(:text, non_null(:string))
+      arg(:price, :float)
+      arg(:quantity, :float)
+      arg(:list_id, :id)
+      resolve(&Resolvers.Groceries.add_item/3)
     end
   end
 end

--- a/test/grok_store/accounts_test.exs
+++ b/test/grok_store/accounts_test.exs
@@ -2,6 +2,7 @@ defmodule GrokStore.AccountsTest do
   use GrokStore.DataCase
 
   alias GrokStore.Accounts
+  alias GrokStore.Repo
 
   describe "users" do
     alias GrokStore.Accounts.User
@@ -91,6 +92,15 @@ defmodule GrokStore.AccountsTest do
       list2 = GrokStore.GroceryHelper.list_fixture()
       assert {:ok, %User{} = user} = Accounts.add_list(user, list2)
       assert [list2, list] == user.lists
+    end
+
+    test "get_user_list/2 fetches a list if the user is a member" do
+      user = user_fixture()
+      list = GrokStore.GroceryHelper.list_fixture()
+      assert nil == Accounts.get_user_list(user, list.id)
+      Accounts.add_list(user, list)
+      list = Repo.preload(list, [:users])
+      assert list == Accounts.get_user_list(user, list.id)
     end
   end
 end

--- a/test/grok_store_web/absinthe/mutations/list_test.exs
+++ b/test/grok_store_web/absinthe/mutations/list_test.exs
@@ -1,0 +1,130 @@
+defmodule GrokStoreWeb.Absinthe.Mutations.ListTest do
+  use GrokStoreWeb.ConnCase
+  alias GrokStore.Accounts
+  alias GrokStoreWeb.Schema
+  alias GrokStore.Groceries.List, as: GList
+  alias GrokStore.Groceries
+
+  setup do
+    {:ok, user} =
+      Accounts.create_user(%{
+        name: "Treebeard",
+        email: "treebeard@fangorn.com",
+        password: "the ent wives"
+      })
+
+    {:ok, list} =
+      Groceries.create_list(%{
+        title: "Water"
+      })
+
+    {:ok, user} = Accounts.add_list(user, list)
+
+    {:ok, user: user, list: list}
+  end
+
+  describe "create" do
+    test "returns list info on creation", %{user: user} do
+      query = """
+      mutation ListCreate {
+        createList(title: "Water") {
+          title
+          items {
+            text
+          }
+          users {
+            id
+            name
+            email
+          }
+        }
+      }
+      """
+
+      {:ok, %{data: %{"createList" => list}}} =
+        Absinthe.run(query, Schema, context: %{user: user})
+
+      assert list["title"] == "Water"
+
+      assert [%{"id" => to_string(user.id), "name" => user.name, "email" => user.email}] ==
+               list["users"]
+
+      assert list["items"] == []
+    end
+
+    test "returns an error if no user is signed in" do
+      query = """
+      mutation ListCreate {
+        createList(title: "Water") {
+          title
+        }
+      }
+      """
+
+      {:ok, %{errors: [error | []]}} = Absinthe.run(query, Schema)
+
+      assert "You must be signed in to create a list" == error[:message]
+    end
+  end
+
+  describe "addItem" do
+    test "adds an item to a list", %{list: list, user: user} do
+      query = """
+      mutation AddItem {
+        addItem(listId: #{list.id}, text: "draught", price: 12.99, quantity: 2) {
+          text
+          price
+          quantity
+          checked
+          listId
+        }
+      }
+      """
+
+      {:ok, %{data: %{"addItem" => item}}} = Absinthe.run(query, Schema, context: %{user: user})
+
+      assert item == %{
+               "text" => "draught",
+               "price" => 12.99,
+               "quantity" => 2.0,
+               "checked" => false,
+               "listId" => to_string(list.id)
+             }
+    end
+  end
+
+  test "only signed in users can add items to lists", %{list: list} do
+    query = """
+    mutation AddItem {
+      addItem(listId: #{list.id}, text: "Salmon") {
+        text
+      }
+    }
+    """
+
+    {:ok, %{errors: [error | []]}} = Absinthe.run(query, Schema)
+
+    assert error[:message] == "You must be signed in to add an item to a list"
+  end
+
+  test "signed in users can only add items to lists they are members of", %{list: list} do
+    query = """
+    mutation AddItem {
+      addItem(listId: #{list.id}, text: "Salmon") {
+        text
+      }
+    }
+    """
+
+    {:ok, user_2} =
+      Accounts.create_user(%{
+        name: "Gollum",
+        email: "smeagol@misty-mountains.net",
+        password: "the precious"
+      })
+
+    {:ok, %{errors: [error | []]}} = Absinthe.run(query, Schema, context: %{user: user_2})
+
+    assert error[:message] == "You must be a member of the list to add to it"
+  end
+end


### PR DESCRIPTION
Adds a mutation to add items to lists. List items only really need a
text to describe them. Users can only add items to a list if they are
signed in and a member of the list.