### PR TITLE
Add an endpoint to toggle item checked

### DIFF
--- a/lib/grok_store/groceries.ex
+++ b/lib/grok_store/groceries.ex
@@ -228,6 +228,14 @@ defmodule GrokStore.Groceries do
   end
 
   @doc """
+  Toggles an item's checked status
+  """
+  def check_item(item) do
+    ListItem.changeset(item, %{checked: !item.checked})
+    |> Repo.update()
+  end
+
+  @doc """
   Returns all the items in a list
   """
   def list_items_in_list(%List{} = list) do

--- a/lib/grok_store_web/resolvers/groceries.ex
+++ b/lib/grok_store_web/resolvers/groceries.ex
@@ -39,4 +39,22 @@ defmodule GrokStoreWeb.Resolvers.Groceries do
   def add_item(_parent, _args, _info) do
     {:error, "You must be signed in to add an item to a list"}
   end
+
+  def check_item(_parent, args, %{context: %{user: user}}) do
+    list_item =
+      GrokStore.Groceries.get_list_item!(args[:id])
+      |> GrokStore.Repo.preload([:list])
+
+    case Accounts.get_user_list(user, list_item.list.id) do
+      nil ->
+        {:error, "You must be a member of a list to check an item on it"}
+
+      _list ->
+        GrokStore.Groceries.check_item(list_item)
+    end
+  end
+
+  def check_item(_parent, _args, _context) do
+    {:error, "You must be signed in to check an item"}
+  end
 end

--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -49,5 +49,11 @@ defmodule GrokStoreWeb.Schema do
       arg(:list_id, :id)
       resolve(&Resolvers.Groceries.add_item/3)
     end
+
+    @desc "Toggles the checked status on an item"
+    field :check_item, type: :item do
+      arg(:id, non_null(:id))
+      resolve(&Resolvers.Groceries.check_item/3)
+    end
   end
 end

--- a/test/grok_store/groceries_test.exs
+++ b/test/grok_store/groceries_test.exs
@@ -158,5 +158,18 @@ defmodule GrokStore.GroceriesTest do
       assert list_item.quantity == item[:quantity]
       assert list_item.checked == false
     end
+
+    test "check_item/1 toggles an item's checked status" do
+      item = list_item_fixture()
+
+      {:ok, checked} = Groceries.check_item(item)
+      db_checked = Groceries.get_list_item!(item.id)
+      assert checked.checked == false
+      assert db_checked == checked
+      {:ok, unchecked} = Groceries.check_item(checked)
+      assert unchecked.checked == true
+      db_unchecked = Groceries.get_list_item!(item.id)
+      assert db_unchecked == unchecked
+    end
   end
 end


### PR DESCRIPTION
Adds an endpoint to toggle whether an item is checked. Again a user must
be logged in and a member of the list that the item belongs to to be
able to toggle the item.